### PR TITLE
Removed references to requiring DCO on contributions

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,4 +1,0 @@
-# This enables DCO bot for you, please take a look https://github.com/probot/dco
-# for more details.
-require:
-  members: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,20 +1,7 @@
 ## Contributing
 This repository is provided as a sample and is not yet accepting contributions.
 In the near future, we hope to clear the necessary legalese to accept contributions so that this repository
-can fulfil its purpose as a community effort for Keycloak practitioners in health IT.
-
-## Future planning
-Once we are clear to accept external contributions, we plan to use the [Developer's Certificate of Origin 1.1 (DCO)](https://github.com/hyperledger/fabric/blob/master/docs/source/DCO1.1.txt) to ensure good pedigree.
-
-All contributors must provide a [Developer's Certificate of Origin 1.1 (DCO)](https://github.com/hyperledger/fabric/blob/master/docs/source/DCO1.1.txt) sign-off for each commit, so please read the text of the DCO and add a line like the following to the end of each commit message:
-```
-Signed-off-by: Author Name <author.email@example.com>
-```
-
-Hint:  git will add this line automatically if you pass the `-s` (`--signoff`) flag to your git commit.
-
-The repository has been configured with the [DCO bot](https://github.com/probot/dco), which ensures that
-all contributions are "signed off" before they are be merged.
+can fulfill its purpose as a community effort for Keycloak practitioners in health IT.
 
 ### Merge approval
 
@@ -30,7 +17,7 @@ Software License 2.0. Using the SPDX format is the simplest approach.
 
 ```
 /*
-Copyright <holder> All Rights Reserved.
+(C) Copyright IBM Corp. 2021
 
 SPDX-License-Identifier: Apache-2.0
 */

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This field is mapped to a user attribute via a Keycloak *Attribute Importer* and
 1. the issued access token via a Keycloak *User Attribute* mapper; and
 2. the token response via the *Token Response Mapper* Keycloak extension from this repository (requires Keycloak 12.x or above).
 
-Note: the TokenResponseMapper extension will be deprecated and removed from this repository once the built-in Keycloak *User Attribute* mapper has been updated to support this pattern. See https://github.com/keycloak/keycloak/pull/7773.
+Note: the TokenResponseMapper extension will be deprecated and removed from this repository once the built-in Keycloak *User Attribute* mapper has been updated to support this pattern.
 
 #### Bill of materials
 | Component | Description |
@@ -34,7 +34,7 @@ Note: the TokenResponseMapper extension will be deprecated and removed from this
 ### Standalone app launch with context picker and an external Identity Provider
 In this pattern, Keycloak is used to broker users from one or more external OpenID Connect (OIDC) Identity Provider (IdP) and IdPs are required to pass the set of Patient resource ids (or something that can be mapped to the Patient resource ids) for which the user has access.
 
-The IdP passes the Patient resource ids (or something that can be mapped to the Patient resource ids) to Keycloak via a pre-coordinated field on the IdP-issued id token or its corresponding userinfo/introspection response.
+The IdP passes the corresponding Patient resource id (or something that can be mapped to the Patient resource id) to Keycloak via a pre-coordinated field on the IdP-issued id token or its corresponding userinfo/introspection response.
 
 If the client application has requested the `launch/patient` scope, Keycloak will present a Patient context picker and the end user must select which patient to use for the scope of the current session.
 
@@ -47,16 +47,6 @@ TBD
 Are you using Keycloak for SMART on FHIR or other health APIs? If so, we'd love to hear from you.
 Connect with us at https://chat.fhir.org/#narrow/stream/179170-smart/topic/Keycloak.20for.20SMART.20authz
 or open an [issue][issues].
-
-All contributors must provide a [Developer's Certificate of Origin 1.1 (DCO)](https://github.com/hyperledger/fabric/blob/master/docs/source/DCO1.1.txt) sign-off for each commit, so please read the text of the DCO and add the following line to the end of each commit message:
-```
-Signed-off-by: Author Name <author.email@example.com>
-```
-
-Hint:  git will add this line automatically if you pass the `-s` (`--signoff`) flag to your git commit.
-
-The repository has been configured with the [DCO bot](https://github.com/probot/dco), which ensures that
-all contributions are "signed off" before they are be merged.
 
 ## License
 All source files must include a Copyright and License header. The SPDX license header is

--- a/keycloak-config/src/main/java/org/alvearie/keycloak/config/InitializeKeycloakConfig.java
+++ b/keycloak-config/src/main/java/org/alvearie/keycloak/config/InitializeKeycloakConfig.java
@@ -1,9 +1,8 @@
 /*
- * (C) Copyright IBM Corp. 2021
- *
- * SPDX-License-Identifier: Apache-2.0
- */
+(C) Copyright IBM Corp. 2021
 
+SPDX-License-Identifier: Apache-2.0
+*/
 package org.alvearie.keycloak.config;
 
 import java.util.ArrayList;

--- a/keycloak-config/src/main/java/org/alvearie/keycloak/config/util/KeycloakConfig.java
+++ b/keycloak-config/src/main/java/org/alvearie/keycloak/config/util/KeycloakConfig.java
@@ -1,9 +1,8 @@
 /*
- * (C) Copyright IBM Corp. 2021
- *
- * SPDX-License-Identifier: Apache-2.0
- */
+(C) Copyright IBM Corp. 2021
 
+SPDX-License-Identifier: Apache-2.0
+*/
 package org.alvearie.keycloak.config.util;
 
 import java.io.File;

--- a/keycloak-config/src/main/java/org/alvearie/keycloak/config/util/PropertyGroup.java
+++ b/keycloak-config/src/main/java/org/alvearie/keycloak/config/util/PropertyGroup.java
@@ -1,9 +1,8 @@
 /*
- * (C) Copyright IBM Corp. 2021
- *
- * SPDX-License-Identifier: Apache-2.0
- */
+(C) Copyright IBM Corp. 2021
 
+SPDX-License-Identifier: Apache-2.0
+*/
 package org.alvearie.keycloak.config.util;
 
 import java.util.ArrayList;

--- a/keycloak-extensions/src/main/java/org/alvearie/keycloak/AudienceValidator.java
+++ b/keycloak-extensions/src/main/java/org/alvearie/keycloak/AudienceValidator.java
@@ -1,8 +1,8 @@
 /*
- * (C) Copyright IBM Corp. 2021
- *
- * SPDX-License-Identifier: Apache-2.0
- */
+(C) Copyright IBM Corp. 2021
+
+SPDX-License-Identifier: Apache-2.0
+*/
 package org.alvearie.keycloak;
 
 import java.util.Arrays;

--- a/keycloak-extensions/src/main/java/org/alvearie/keycloak/AudienceValidatorFactory.java
+++ b/keycloak-extensions/src/main/java/org/alvearie/keycloak/AudienceValidatorFactory.java
@@ -1,8 +1,8 @@
 /*
- * (C) Copyright IBM Corp. 2021
- *
- * SPDX-License-Identifier: Apache-2.0
- */
+(C) Copyright IBM Corp. 2021
+
+SPDX-License-Identifier: Apache-2.0
+*/
 package org.alvearie.keycloak;
 
 import org.keycloak.Config;
@@ -23,7 +23,7 @@ public class AudienceValidatorFactory implements AuthenticatorFactory {
 
     private static final String PROVIDER_ID = "audience-validator";
     static final String AUDIENCES = "Audiences";
-    
+
     @Override
     public String getDisplayType() {
         return "Audience Validation";
@@ -62,7 +62,7 @@ public class AudienceValidatorFactory implements AuthenticatorFactory {
 
     @Override
     public List<ProviderConfigProperty> getConfigProperties() {
-        return Collections.singletonList(new ProviderConfigProperty("Audiences", "Audiences", 
+        return Collections.singletonList(new ProviderConfigProperty("Audiences", "Audiences",
                 "Valid audiences for clients to request", ProviderConfigProperty.MULTIVALUED_STRING_TYPE, null));
     }
 

--- a/keycloak-extensions/src/main/java/org/alvearie/keycloak/PatientPrefixUserAttributeMapper.java
+++ b/keycloak-extensions/src/main/java/org/alvearie/keycloak/PatientPrefixUserAttributeMapper.java
@@ -1,8 +1,8 @@
 /*
- * (C) Copyright IBM Corp. 2021
- *
- * SPDX-License-Identifier: Apache-2.0
- */
+(C) Copyright IBM Corp. 2021
+
+SPDX-License-Identifier: Apache-2.0
+*/
 package org.alvearie.keycloak;
 
 import java.util.ArrayList;

--- a/keycloak-extensions/src/main/resources/META-INF/jboss-deployment-structure.xml
+++ b/keycloak-extensions/src/main/resources/META-INF/jboss-deployment-structure.xml
@@ -1,7 +1,0 @@
-<jboss-deployment-structure>
-    <deployment>
-        <dependencies>
-            <module name="org.keycloak.keycloak-services" />
-        </dependencies>
-    </deployment>
-</jboss-deployment-structure>


### PR DESCRIPTION
I spoke with @eggebraa and we don't believe that the DCO is required for Alvearie projects.
I'm all for anything we can do to make it less burdensome for potential contributors, so I've removed all the DCO stuff.