### PR TITLE
Split InitializeKeycloakConfig and add KeycloakContainerTest

### DIFF
--- a/keycloak-config/src/main/java/org/alvearie/keycloak/config/Main.java
+++ b/keycloak-config/src/main/java/org/alvearie/keycloak/config/Main.java
@@ -27,7 +27,7 @@ import org.keycloak.admin.client.resource.RealmsResource;
 public class Main {
 
     private static final String CONFIG_FILE_PATH_OPTION = "configFile";
-    private static final String CLASS_NAME = "InitializeKeycloakConfig";
+    private static final String CLASS_NAME = "Main";
     private static final String MASTER_REALM = "master";
 
     /**

--- a/keycloak-config/src/main/java/org/alvearie/keycloak/config/Main.java
+++ b/keycloak-config/src/main/java/org/alvearie/keycloak/config/Main.java
@@ -1,0 +1,111 @@
+/*
+(C) Copyright IBM Corp. 2021
+
+SPDX-License-Identifier: Apache-2.0
+*/
+package org.alvearie.keycloak.config;
+
+import org.alvearie.keycloak.config.util.KeycloakConfig;
+import org.alvearie.keycloak.config.util.PropertyGroup;
+import org.alvearie.keycloak.config.util.PropertyGroup.PropertyEntry;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.KeycloakBuilder;
+import org.keycloak.admin.client.resource.RealmsResource;
+
+/**
+ * Reads the KeycloakConfig and applies it to the target Keycloak
+ *
+ * Command line arguments:
+ *   configFile: the file path to a JSON file containing Keycloak configuration properties
+ */
+public class Main {
+
+    private static final String CONFIG_FILE_PATH_OPTION = "configFile";
+    private static final String CLASS_NAME = "InitializeKeycloakConfig";
+    private static final String MASTER_REALM = "master";
+
+    /**
+     * Initializes the Keycloak configuration.
+     * @param args the passed in arguments
+     * @throws Exception
+     */
+    public static void main(String[] args) throws Exception {
+        Options options = null;
+        CommandLine cmd;
+        String configFilePath;
+
+        try {
+            // Process the options
+            options = buildCmdOptions();
+            cmd = new DefaultParser().parse(options, args);
+            configFilePath = cmd.getOptionValue(CONFIG_FILE_PATH_OPTION);
+        } catch (ParseException e) {
+            String header = "Initialize keycloak config\n\n";
+            String footer = "\n";
+            HelpFormatter formatter = new HelpFormatter();
+            formatter.printHelp(CLASS_NAME, header, options, footer, true);
+            throw new RuntimeException("Invalid arguments", e);
+        }
+
+        // Perform the action
+        KeycloakConfig config = new KeycloakConfig(configFilePath);
+        applyConfig(config);
+    }
+
+    /**
+     * Builds the command options.
+     * @return the command options
+     */
+    private static Options buildCmdOptions() {
+        Options options = new Options();
+
+        Option configFilePathOption = new Option(CONFIG_FILE_PATH_OPTION, true, "The file path to a JSON file containing Keycloak configuration properties");
+        configFilePathOption.setRequired(true);
+        options.addOption(configFilePathOption);
+
+        return options;
+    }
+
+    /**
+     * Applies the Keycloak configuration.
+     * @param config the Keycloak configuration to apply
+     * @throws Exception an exception
+     */
+    private static void applyConfig(KeycloakConfig config) throws Exception {
+        // Create a Keycloak client and use that to initialize the configurator
+        Keycloak client = createKeycloakClient(config);
+        KeycloakConfigurator configurator = new KeycloakConfigurator(client);
+
+        // Initialize realms
+        PropertyGroup realmsPg = config.getPropertyGroup(KeycloakConfig.PROP_KEYCLOAK_REALMS);
+        if (realmsPg != null) {
+            for (PropertyEntry realmPe: realmsPg.getProperties()) {
+                String realmName = realmPe.getName();
+                PropertyGroup realmPg = realmsPg.getPropertyGroup(realmName);
+                configurator.initializeRealm(realmName, realmPg);
+            }
+        }
+    }
+
+    /**
+     * Creates a Keycloak admin client.
+     * @param config the Keycloak configuration to initialize
+     * @return a Keycloak client
+     */
+    private static Keycloak createKeycloakClient(KeycloakConfig config) {
+        Keycloak keycloak = KeycloakBuilder.builder()
+                .serverUrl(config.getStringProperty(KeycloakConfig.PROP_KEYCLOAK_SERVER_URL))
+                .realm(MASTER_REALM)
+                .username(config.getStringProperty(KeycloakConfig.PROP_KEYCLOAK_ADMIN_USER))
+                .password(config.getStringProperty(KeycloakConfig.PROP_KEYCLOAK_ADMIN_PW))
+                .clientId(config.getStringProperty(KeycloakConfig.PROP_KEYCLOAK_ADMIN_CLIENT_ID))
+                .build();
+        return keycloak;
+    }
+}

--- a/keycloak-extensions/pom.xml
+++ b/keycloak-extensions/pom.xml
@@ -10,6 +10,7 @@
 
     <properties>
         <keycloak.version>12.0.3</keycloak.version>
+        <testcontainers.version>1.15.1</testcontainers.version>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
     </properties>
@@ -32,12 +33,48 @@
             <artifactId>keycloak-services</artifactId>
             <version>${keycloak.version}</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-server-spi-private</artifactId>
             <version>${keycloak.version}</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.alvearie</groupId>
+            <artifactId>keycloak-config</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.dasniko</groupId>
+            <artifactId>testcontainers-keycloak</artifactId>
+            <version>1.5.1-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <version>4.1.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.3</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/keycloak-extensions/pom.xml
+++ b/keycloak-extensions/pom.xml
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>com.github.dasniko</groupId>
             <artifactId>testcontainers-keycloak</artifactId>
-            <version>1.5.1-SNAPSHOT</version>
+            <version>1.6.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/keycloak-extensions/src/main/resources/META-INF/jboss-deployment-structure.xml
+++ b/keycloak-extensions/src/main/resources/META-INF/jboss-deployment-structure.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jboss-deployment-structure>
+    <deployment>
+        <dependencies>
+            <module name="org.keycloak.keycloak-services" />
+        </dependencies>
+    </deployment>
+</jboss-deployment-structure>

--- a/keycloak-extensions/src/test/java/org/alvearie/keycloak/KeycloakContainerTest.java
+++ b/keycloak-extensions/src/test/java/org/alvearie/keycloak/KeycloakContainerTest.java
@@ -1,0 +1,59 @@
+/*
+(C) Copyright IBM Corp. 2021
+
+SPDX-License-Identifier: Apache-2.0
+*/
+package org.alvearie.keycloak;
+
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+import org.alvearie.keycloak.config.KeycloakConfigurator;
+import org.alvearie.keycloak.config.util.KeycloakConfig;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.KeycloakBuilder;
+import org.keycloak.representations.info.ServerInfoRepresentation;
+
+import dasniko.testcontainers.keycloak.KeycloakContainer;
+
+public class KeycloakContainerTest {
+    private static final String MASTER_REALM = "master";
+    private static final String CLIENT_ID = "admin-cli";
+
+    private static KeycloakContainer keycloak;
+    private static Keycloak adminClient;
+
+    @SuppressWarnings("resource")
+    @BeforeClass
+    public static void start() throws Exception {
+        keycloak = new KeycloakContainer().withExtensionClassesFrom("target/classes");
+        // Shouldn't be needed, but is: https://github.com/dasniko/testcontainers-keycloak/issues/15
+        keycloak.withEnv("DB_VENDOR", "H2");
+        keycloak.start();
+
+        adminClient = KeycloakBuilder.builder()
+                .serverUrl(keycloak.getAuthServerUrl())
+                .realm(MASTER_REALM)
+                .username(keycloak.getAdminUsername())
+                .password(keycloak.getAdminPassword())
+                .clientId(CLIENT_ID)
+                .build();
+        KeycloakConfigurator configurator = new KeycloakConfigurator(adminClient);
+        KeycloakConfig config = new KeycloakConfig("keycloak-config.json");
+        configurator.initializeRealm("test", config.getPropertyGroup("test"));
+    }
+
+    @AfterClass
+    public static void end() {
+        keycloak.close();
+    }
+
+    @Test
+    public void shouldReturnServerInfo() {
+        ServerInfoRepresentation serverInfo = adminClient.serverInfo().getInfo();
+        assertThat(serverInfo, notNullValue());
+    }
+}

--- a/keycloak-extensions/src/test/resources/keycloak-config.json
+++ b/keycloak-extensions/src/test/resources/keycloak-config.json
@@ -1,0 +1,80 @@
+{
+	"test": {
+		"enabled": true,
+		"clientScopes": {
+			"fhirUser": {
+				"protocol": "openid-connect",
+				"description": "Permission to retrieve current logged-in user",
+				"attributes": {
+					"consent.screen.text": "Permission to retrieve current logged-in user"
+				},
+				"mappers": {
+					"fhirUser Mapper": {
+						"protocol": "openid-connect",
+						"protocolmapper": "oidc-patient-prefix-usermodel-attribute-mapper",
+						"config": {
+							"user.attribute": "resourceId",
+							"claim.name": "fhirUser",
+							"jsonType.label": "String",
+							"id.token.claim": "true",
+							"access.token.claim": "false",
+							"userinfo.token.claim": "true"
+						}
+					}
+				}
+			},
+			"profile": {
+				"protocol": "openid-connect",
+				"mappers": {
+					"Patient ID Claim Mapper": {
+						"protocol": "openid-connect",
+						"protocolmapper": "oidc-usermodel-attribute-mapper",
+						"config": {
+							"user.attribute": "resourceId",
+							"jsonType.label": "String",
+							"claim.name": "patient_id",
+							"id.token.claim": "false",
+							"access.token.claim": "true",
+							"userinfo.token.claim": "false"
+						}
+					},
+					"Patient ID Token Mapper": {
+						"protocol": "openid-connect",
+						"protocolmapper": "oidc-usermodel-attribute-mapper",
+						"config": {
+							"user.attribute": "resourceId",
+							"jsonType.label": "String",
+							"claim.name": "patient_id",
+							"id.token.claim": "false",
+							"access.token.claim": "true",
+							"userinfo.token.claim": "false"
+						}
+					}
+				}
+			}
+		},
+		"defaultDefaultClientScopes": ["profile"],
+		"defaultOptionalClientScopes": [
+			"fhirUser"
+		],
+		"clients": {
+			"test": {
+				"consentRequired": false,
+				"publicClient": true,
+				"bearerOnly": false,
+				"rootURL": "http://localhost",
+				"redirectURIs": ["http://localhost/*"]
+			}
+		},
+		"users": {
+			"a": {
+				"enabled": true,
+				"password": "a",
+				"passwordTemporary": false,
+				"attributes": {
+					"resourceId": ["Patient0000"]
+				}
+			}
+		}
+	}
+}

--- a/keycloak-extensions/src/test/resources/logback-test.xml
+++ b/keycloak-extensions/src/test/resources/logback-test.xml
@@ -1,0 +1,14 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <logger name="org.testcontainers" level="INFO"/>
+    <logger name="com.github.dockerjava" level="WARN"/>
+</configuration>


### PR DESCRIPTION
1. Introduce a dependency on the Keycloak testcontainers project
  * Note: this depends on a yet-to-be-released SNAPSHOT version of
https://github.com/dasniko/testcontainers-keycloak
2. Split InitializeKeycloakConfig into a Main and a Configurator; this
should make it easier to use the configurator from the new test
3. Introduce a placeholder test that
  * Uses the testcontainers-keycloak project to launch a keycloak
container from the JUnit
  * Uses the keycloak-config project to configure the container with a
test tenant
  * Retrieves the server info
4. Add the `jboss-deployment-structure.xml` back in. I wasn't sure if it
was needed or not but without it I'm seeing
"java.lang.NoClassDefFoundError: Failed to link" errors while
initializing the test realm with a PatientPrefixUserAttributeMapper.