### PR TITLE
avoid unneccessary checking of the fhir server response

### DIFF
--- a/keycloak-extensions/src/main/java/org/alvearie/keycloak/PatientSelectionForm.java
+++ b/keycloak-extensions/src/main/java/org/alvearie/keycloak/PatientSelectionForm.java
@@ -44,6 +44,7 @@ import org.keycloak.services.util.DefaultClientSessionContext;
 import org.keycloak.sessions.AuthenticationSessionModel;
 
 import com.ibm.fhir.core.FHIRMediaType;
+import com.ibm.fhir.model.config.FHIRModelConfig;
 import com.ibm.fhir.model.resource.Bundle;
 import com.ibm.fhir.model.resource.Bundle.Entry;
 import com.ibm.fhir.model.resource.Patient;
@@ -72,6 +73,7 @@ public class PatientSelectionForm implements Authenticator {
     private Client fhirClient;
 
     public PatientSelectionForm() {
+        FHIRModelConfig.setExtendedCodeableConceptValidation(false);
         fhirClient = ResteasyClientBuilder.newClient()
                 .register(new FHIRProvider(RuntimeType.CLIENT));
     }


### PR DESCRIPTION
without this, I was getting the following error:
```
ERROR [org.keycloak.services.error.KeycloakErrorHandler] (default
task-2) Uncaught server error: java.lang.Error:
java.io.FileNotFoundException: File not found: language-subtag-registry
	at com.ibm.fhir//com.ibm.fhir.model.lang.util.LanguageRegistry$LanguageRegistryInitializer.getLanguageSubTagRegistryEntries(LanguageRegistry.java:345)
	at com.ibm.fhir//com.ibm.fhir.model.lang.util.LanguageRegistry$LanguageRegistryInitializer.buildLanguages(LanguageRegistry.java:167)
	at com.ibm.fhir//com.ibm.fhir.model.lang.util.LanguageRegistry$LanguageRegistryInitializer.access$000(LanguageRegistry.java:137)
	at com.ibm.fhir//com.ibm.fhir.model.lang.util.LanguageRegistry.<clinit>(LanguageRegistry.java:28)
	at com.ibm.fhir//com.ibm.fhir.model.lang.util.LanguageRegistryUtil.isValidLanguageTag(LanguageRegistryUtil.java:47)
	at com.ibm.fhir//com.ibm.fhir.model.util.ValidationSupport.checkSyntaxValidatedCode(ValidationSupport.java:611)
	at com.ibm.fhir//com.ibm.fhir.model.util.ValidationSupport.checkCode(ValidationSupport.java:592)
	at com.ibm.fhir//com.ibm.fhir.model.util.ValidationSupport.checkValueSetBinding(ValidationSupport.java:513)
	at com.ibm.fhir//com.ibm.fhir.model.resource.Resource.<init>(Resource.java:64)
	at com.ibm.fhir//com.ibm.fhir.model.resource.DomainResource.<init>(DomainResource.java:78)
	at com.ibm.fhir//com.ibm.fhir.model.resource.Patient.<init>(Patient.java:139)
	at com.ibm.fhir//com.ibm.fhir.model.resource.Patient.<init>(Patient.java:92)
	at com.ibm.fhir//com.ibm.fhir.model.resource.Patient$Builder.build(Patient.java:1134)
	at com.ibm.fhir//com.ibm.fhir.model.parser.FHIRJsonParser.parsePatient(FHIRJsonParser.java:15849)
	at com.ibm.fhir//com.ibm.fhir.model.parser.FHIRJsonParser.parseResource(FHIRJsonParser.java:333)
	at com.ibm.fhir//com.ibm.fhir.model.parser.FHIRJsonParser.parseBundleEntry(FHIRJsonParser.java:1568)
	at com.ibm.fhir//com.ibm.fhir.model.parser.FHIRJsonParser.parseBundle(FHIRJsonParser.java:1543)
	at com.ibm.fhir//com.ibm.fhir.model.parser.FHIRJsonParser.parseResource(FHIRJsonParser.java:151)
	at com.ibm.fhir//com.ibm.fhir.model.parser.FHIRJsonParser.parseAndFilter(FHIRJsonParser.java:104)
	at com.ibm.fhir//com.ibm.fhir.model.parser.FHIRJsonParser.parseAndFilter(FHIRJsonParser.java:67)
	at com.ibm.fhir//com.ibm.fhir.model.parser.FHIRJsonParser.parse(FHIRJsonParser.java:61)
	at com.ibm.fhir//com.ibm.fhir.provider.FHIRProvider.readFrom(FHIRProvider.java:92)
	at com.ibm.fhir//com.ibm.fhir.provider.FHIRProvider.readFrom(FHIRProvider.java:56)
	at org.jboss.resteasy.resteasy-jaxrs@3.13.2.Final//org.jboss.resteasy.core.interception.AbstractReaderInterceptorContext.readFrom(AbstractReaderInterceptorContext.java:66)
	at org.jboss.resteasy.resteasy-jaxrs@3.13.2.Final//org.jboss.resteasy.core.interception.AbstractReaderInterceptorContext.proceed(AbstractReaderInterceptorContext.java:56)
	at org.jboss.resteasy.resteasy-crypto@3.13.2.Final//org.jboss.resteasy.security.doseta.DigitalVerificationInterceptor.aroundReadFrom(DigitalVerificationInterceptor.java:36)
	at org.jboss.resteasy.resteasy-jaxrs@3.13.2.Final//org.jboss.resteasy.core.interception.AbstractReaderInterceptorContext.proceed(AbstractReaderInterceptorContext.java:59)
	at org.jboss.resteasy.resteasy-jaxrs@3.13.2.Final//org.jboss.resteasy.client.jaxrs.internal.ClientResponse.readFrom(ClientResponse.java:211)
	at org.jboss.resteasy.resteasy-jaxrs@3.13.2.Final//org.jboss.resteasy.specimpl.BuiltResponse.readEntity(BuiltResponse.java:88)
	at org.jboss.resteasy.resteasy-jaxrs@3.13.2.Final//org.jboss.resteasy.specimpl.AbstractBuiltResponse.readEntity(AbstractBuiltResponse.java:262)
	at deployment.keycloak-extensions-0.0.1-SNAPSHOT.jar//org.alvearie.keycloak.PatientSelectionForm.authenticate(PatientSelectionForm.java:140)
	at org.keycloak.keycloak-services@12.0.4//org.keycloak.authentication.DefaultAuthenticationFlow.processSingleFlowExecutionModel(DefaultAuthenticationFlow.java:446)
	at org.keycloak.keycloak-services@12.0.4//org.keycloak.authentication.DefaultAuthenticationFlow.processFlow(DefaultAuthenticationFlow.java:253)
	at org.keycloak.keycloak-services@12.0.4//org.keycloak.authentication.DefaultAuthenticationFlow.processSingleFlowExecutionModel(DefaultAuthenticationFlow.java:389)
	at org.keycloak.keycloak-services@12.0.4//org.keycloak.authentication.DefaultAuthenticationFlow.continueAuthenticationAfterSuccessfulAction(DefaultAuthenticationFlow.java:186)
	at org.keycloak.keycloak-services@12.0.4//org.keycloak.authentication.DefaultAuthenticationFlow.processAction(DefaultAuthenticationFlow.java:164)
	at org.keycloak.keycloak-services@12.0.4//org.keycloak.authentication.AuthenticationProcessor.authenticationAction(AuthenticationProcessor.java:937)
	at org.keycloak.keycloak-services@12.0.4//org.keycloak.services.resources.LoginActionsService.processFlow(LoginActionsService.java:311)
	at org.keycloak.keycloak-services@12.0.4//org.keycloak.services.resources.LoginActionsService.processAuthentication(LoginActionsService.java:282)
	at org.keycloak.keycloak-services@12.0.4//org.keycloak.services.resources.LoginActionsService.authenticate(LoginActionsService.java:266)
	at org.keycloak.keycloak-services@12.0.4//org.keycloak.services.resources.LoginActionsService.authenticateForm(LoginActionsService.java:339)
```