### PR TITLE
Bump the Docker image to keycloak 13.0.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # ----------------------------------------------------------------------------
 
-FROM quay.io/keycloak/keycloak:12.0.4
+FROM quay.io/keycloak/keycloak:13.0.1
 
 # This can be overridden, but without this I've found the db vendor-detection in Keycloak to be brittle
 ENV DB_VENDOR=H2

--- a/keycloak-config/src/main/java/org/alvearie/keycloak/config/Main.java
+++ b/keycloak-config/src/main/java/org/alvearie/keycloak/config/Main.java
@@ -5,6 +5,8 @@ SPDX-License-Identifier: Apache-2.0
 */
 package org.alvearie.keycloak.config;
 
+import javax.ws.rs.BadRequestException;
+
 import org.alvearie.keycloak.config.util.KeycloakConfig;
 import org.alvearie.keycloak.config.util.PropertyGroup;
 import org.alvearie.keycloak.config.util.PropertyGroup.PropertyEntry;
@@ -53,8 +55,13 @@ public class Main {
         }
 
         // Perform the action
-        KeycloakConfig config = new KeycloakConfig(configFilePath);
-        applyConfig(config);
+        try {
+            KeycloakConfig config = new KeycloakConfig(configFilePath);
+            applyConfig(config);
+        } catch (BadRequestException e) {
+            System.err.println(e.getResponse().readEntity(String.class));
+            throw e;
+        }
     }
 
     /**


### PR DESCRIPTION
Previously I bumped the version in the pom.xml but I missed the
corresponding update in the Dockerfile.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>