### PR TITLE
Update dependencies and align PropertyGroup with ibm/fhir

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "lmsurpre"

--- a/keycloak-config/pom.xml
+++ b/keycloak-config/pom.xml
@@ -41,6 +41,18 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <addClasspath>true</addClasspath>
+              <mainClass>org.alvearie.keycloak.config.Main</mainClass>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <version>3.1.2</version>
         <executions>

--- a/keycloak-config/pom.xml
+++ b/keycloak-config/pom.xml
@@ -16,7 +16,7 @@
       <artifactId>keycloak-admin-client</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.glassfish</groupId>
+      <groupId>org.eclipse.parsson</groupId>
       <artifactId>jakarta.json</artifactId>
     </dependency>
     <dependency>
@@ -30,6 +30,10 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-text</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
     </dependency>
   </dependencies>
 

--- a/keycloak-config/src/main/java/org/alvearie/keycloak/config/util/PropertyGroup.java
+++ b/keycloak-config/src/main/java/org/alvearie/keycloak/config/util/PropertyGroup.java
@@ -257,7 +257,7 @@ public class PropertyGroup {
     public Object[] getArrayProperty(String propertyName) throws Exception {
         Object[] result = null;
         JsonValue jsonValue = getJsonValue(propertyName);
-        if (jsonValue != null && jsonValue.getValueType() != ValueType.NULL) {
+        if (jsonValue != null) {
             if (jsonValue instanceof JsonArray) {
                 result = convertJsonArray((JsonArray) jsonValue);
             } else {
@@ -276,7 +276,10 @@ public class PropertyGroup {
     public List<PropertyEntry> getProperties() throws Exception {
         List<PropertyEntry> results = new ArrayList<>();
         for (Map.Entry<String, JsonValue> entry : jsonObj.entrySet()) {
-            results.add(new PropertyEntry(entry.getKey(), convertJsonValue(entry.getValue())));
+            Object jsonValue = convertJsonValue(entry.getValue());
+            if (jsonValue != null) {
+                results.add(new PropertyEntry(entry.getKey(), jsonValue));
+            }
         }
         return results;
     }
@@ -298,7 +301,7 @@ public class PropertyGroup {
      *
      * @param jsonValue
      *            the JsonValue instance to be converted
-     * @return an instance of Boolean, Integer, String, PropertyGroup, or List<Object>
+     * @return either null or an instance of Boolean, Integer, String, PropertyGroup, or List<Object>
      * @throws Exception
      */
     public static Object convertJsonValue(JsonValue jsonValue) throws Exception {
@@ -328,6 +331,8 @@ public class PropertyGroup {
         case FALSE:
             result = Boolean.FALSE;
             break;
+        case NULL:
+            break;
         default:
             throw new IllegalStateException("Unexpected JSON value type: " + jsonValue.getValueType().name());
         }
@@ -355,6 +360,7 @@ public class PropertyGroup {
      *
      * @param propertyName
      *            the possibly hierarchical property name.
+     * @return the property value as a JsonValue or null if the property is either missing or has a null value
      */
     public JsonValue getJsonValue(String propertyName) {
         String[] pathElements = getPathElements(propertyName);
@@ -363,7 +369,7 @@ public class PropertyGroup {
         if (subGroup != null) {
             result = subGroup.get(pathElements[pathElements.length - 1]);
         }
-        return result;
+        return result == JsonValue.NULL ? null : result;
     }
 
     /**

--- a/keycloak-config/src/test/java/org/alvearie/keycloak/config/util/PropertyGroupTest.java
+++ b/keycloak-config/src/test/java/org/alvearie/keycloak/config/util/PropertyGroupTest.java
@@ -1,0 +1,232 @@
+/*
+ * (C) Copyright IBM Corp. 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.alvearie.keycloak.config.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.alvearie.keycloak.config.util.PropertyGroup.PropertyEntry;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import jakarta.json.Json;
+import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
+import jakarta.json.stream.JsonGenerator;
+import jakarta.json.stream.JsonGeneratorFactory;
+
+public class PropertyGroupTest {
+    private static final JsonBuilderFactory BUILDER_FACTORY = Json.createBuilderFactory(null);
+    private static JsonObject obj = null;
+
+    private static boolean DEBUG = true;
+
+    @BeforeClass
+    public static void setup() {
+        // Build a JSON object for testing.
+        obj = BUILDER_FACTORY.createObjectBuilder()
+                .add("level1", BUILDER_FACTORY.createObjectBuilder()
+                    .add("level2", BUILDER_FACTORY.createObjectBuilder()
+                        .add("scalars", BUILDER_FACTORY.createObjectBuilder()
+                            .add("stringProp", "stringValue")
+                            .add("intProp", 123)
+                            .add("booleanProp", true)
+                            .add("booleanProp-2", "true"))
+                        .add("arrays", BUILDER_FACTORY.createObjectBuilder()
+                            .add("int-array", BUILDER_FACTORY.createArrayBuilder()
+                                    .add(1)
+                                    .add(2)
+                                    .add(3))
+                            .add("string-array", BUILDER_FACTORY.createArrayBuilder()
+                                .add("one")
+                                .add("two"))
+                            .add("object-array", BUILDER_FACTORY.createArrayBuilder()
+                                .add(BUILDER_FACTORY.createObjectBuilder()
+                                    .add("attr1", "val1"))
+                                .add(BUILDER_FACTORY.createObjectBuilder()
+                                    .add("attr2", "val2"))))
+                        .add("nulls", BUILDER_FACTORY.createObjectBuilder()
+                            .add("nullProp", JsonValue.NULL)
+                            .add("nullArrayProp", BUILDER_FACTORY.createArrayBuilder()
+                                .add(JsonValue.NULL)))))
+                .build();
+
+        if (DEBUG) {
+            Map<String, Object> config = Collections.singletonMap(JsonGenerator.PRETTY_PRINTING, true);
+            JsonGeneratorFactory factory = Json.createGeneratorFactory(config);
+            JsonGenerator generator = factory.createGenerator(System.out);
+            generator.write(obj);
+            generator.flush();
+            System.out.println();
+        }
+    }
+
+    @Test
+    public void testGetPropertyGroup() throws Exception {
+        PropertyGroup pg = new PropertyGroup(obj);
+
+        PropertyGroup scalars = pg.getPropertyGroup("level1|level2|scalars");
+        assertNotNull(scalars);
+        PropertyGroup result = scalars.getPropertyGroup("scalars");
+        assertNull(result);
+        String value = scalars.getStringProperty("stringProp");
+        assertNotNull(value);
+        assertEquals("stringValue", value);
+    }
+
+    @Test
+    public void testStringProperty() throws Exception {
+        PropertyGroup pg = new PropertyGroup(obj);
+        String value = pg.getStringProperty("level1|level2|scalars|stringProp");
+        assertNotNull(value);
+        assertEquals("stringValue", value);
+    }
+
+    @Test
+    public void testIntProperty() {
+        PropertyGroup pg = new PropertyGroup(obj);
+        Integer value = pg.getIntProperty("level1|level2|scalars|intProp");
+        assertNotNull(value);
+        assertEquals(123, value.intValue());
+    }
+
+    @Test
+    public void testBooleanProperty() {
+        PropertyGroup pg = new PropertyGroup(obj);
+        Boolean value = pg.getBooleanProperty("level1|level2|scalars|booleanProp");
+        assertNotNull(value);
+        assertEquals(Boolean.TRUE, value);
+
+        value = pg.getBooleanProperty("level1|level2|scalars|booleanProp-2");
+        assertNotNull(value);
+        assertEquals(Boolean.TRUE, value);
+    }
+
+    @Test
+    public void testArrayProperty() throws Exception {
+        PropertyGroup pg = new PropertyGroup(obj);
+        Object[] array = pg.getArrayProperty("level1|level2|arrays|string-array");
+        assertNotNull(array);
+        assertEquals(2, array.length);
+        assertEquals("one", array[0]);
+        assertEquals("two", array[1]);
+    }
+
+    @Test
+    public void testStringListProperty() throws Exception {
+        PropertyGroup pg = new PropertyGroup(obj);
+        List<String> strings = pg.getStringListProperty("level1|level2|arrays|string-array");
+        assertNotNull(strings);
+        assertEquals(2, strings.size());
+        assertEquals("one", strings.get(0));
+        assertEquals("two", strings.get(1));
+
+        strings = pg.getStringListProperty("level1|level2|arrays|int-array");
+        assertNotNull(strings);
+        assertEquals(3, strings.size());
+        assertEquals("1", strings.get(0));
+        assertEquals("2", strings.get(1));
+        assertEquals("3", strings.get(2));
+    }
+
+    @Test
+    public void testObjectArrayProperty() throws Exception {
+        PropertyGroup pg = new PropertyGroup(obj);
+        Object[] array = pg.getArrayProperty("level1|level2|arrays|object-array");
+        assertNotNull(array);
+        assertEquals(2, array.length);
+        if (!(array[0] instanceof PropertyGroup)) {
+            fail("array element 0 not a PropertyGroup!");
+        }
+        if (!(array[1] instanceof PropertyGroup)) {
+            fail("array element 1 not a PropertyGroup!");
+        }
+
+        // Check the first element.
+        PropertyGroup pg0 = (PropertyGroup) array[0];
+        String val1 = pg0.getStringProperty("attr1");
+        assertNotNull(val1);
+        assertEquals("val1", val1);
+
+        // Check the second element.
+        PropertyGroup pg1 = (PropertyGroup) array[1];
+        String val2 = pg1.getStringProperty("attr2");
+        assertNotNull(val2);
+        assertEquals("val2", val2);
+    }
+
+    @Test
+    public void testNullProperty() throws Exception {
+        PropertyGroup pg = new PropertyGroup(obj);
+        assertNull(pg.getJsonValue("level1|level2|nulls|nullProp"));
+        assertNull(pg.getStringProperty("level1|level2|nulls|nullProp"));
+        assertNull(pg.getBooleanProperty("level1|level2|nulls|nullProp"));
+        assertNull(pg.getIntProperty("level1|level2|nulls|nullProp"));
+        assertNull(pg.getDoubleProperty("level1|level2|nulls|nullProp"));
+        assertNull(pg.getStringListProperty("level1|level2|nulls|nullProp"));
+    }
+
+    @Test
+    public void testNonExistentProperty() throws Exception {
+        PropertyGroup pg = new PropertyGroup(obj);
+        assertNull(pg.getJsonValue("bogus"));
+        assertNull(pg.getStringProperty("bogus"));
+        assertNull(pg.getBooleanProperty("bogus"));
+        assertNull(pg.getIntProperty("bogus"));
+        assertNull(pg.getDoubleProperty("bogus"));
+        assertNull(pg.getStringListProperty("bogus"));
+
+        assertNull(pg.getJsonValue("level1|bogus"));
+        assertNull(pg.getStringProperty("level1|bogus"));
+        assertNull(pg.getBooleanProperty("level1|bogus"));
+        assertNull(pg.getIntProperty("level1|bogus"));
+        assertNull(pg.getDoubleProperty("level1|bogus"));
+        assertNull(pg.getStringListProperty("level1|bogus"));
+
+        assertNull(pg.getJsonValue("bogus|bogus"));
+        assertNull(pg.getStringProperty("bogus|bogus"));
+        assertNull(pg.getBooleanProperty("bogus|bogus"));
+        assertNull(pg.getIntProperty("bogus|bogus"));
+        assertNull(pg.getDoubleProperty("bogus|bogus"));
+        assertNull(pg.getStringListProperty("bogus|bogus"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testStringPropertyException() throws Exception {
+        PropertyGroup pg = new PropertyGroup(obj);
+        Object result = pg.getStringProperty("level1|level2|scalars|intProp");
+        System.err.println("Unexpected result: " + result);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testIntPropertyException() {
+        PropertyGroup pg = new PropertyGroup(obj);
+        Object result = pg.getIntProperty("level1|level2|scalars|stringProp");
+        System.err.println("Unexpected result: " + result);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testBooleanPropertyException() {
+        PropertyGroup pg = new PropertyGroup(obj);
+        Object result = pg.getBooleanProperty("level1|level2|scalars|intProp");
+        System.err.println("Unexpected result: " + result);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testArrayPropertyException() throws Exception {
+        PropertyGroup pg = new PropertyGroup(obj);
+        Object result = pg.getArrayProperty("level1|level2");
+        System.err.println("Unexpected result: " + result);
+    }
+}

--- a/keycloak-extensions/pom.xml
+++ b/keycloak-extensions/pom.xml
@@ -25,10 +25,6 @@
     </dependency>
     <dependency>
       <groupId>org.keycloak</groupId>
-      <artifactId>keycloak-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.keycloak</groupId>
       <artifactId>keycloak-server-spi</artifactId>
     </dependency>
     <dependency>

--- a/keycloak-extensions/src/test/resources/jboss/module.xml
+++ b/keycloak-extensions/src/test/resources/jboss/module.xml
@@ -7,8 +7,7 @@
     <resource-root path="fhir-model-4.10.2.jar"/>
     <resource-root path="fhir-core-4.10.2.jar"/>
     <resource-root path="antlr4-runtime-4.9.3.jar"/>
-    <resource-root path="commons-io-2.8.0.jar"/>
-    <resource-root path="commons-lang3-3.12.0.jar"/>
+    <resource-root path="commons-io-2.11.0.jar"/>
     <resource-root path="commons-text-1.9.jar"/>
     <resource-root path="encoder-1.2.3.jar"/>
     <resource-root path="jakarta.annotation-api-1.3.5.jar"/>

--- a/pom.xml
+++ b/pom.xml
@@ -61,19 +61,19 @@
         <version>${keycloak.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.glassfish</groupId>
+        <groupId>org.eclipse.parsson</groupId>
         <artifactId>jakarta.json</artifactId>
-        <version>2.0.1</version>
+        <version>1.0.0</version>
       </dependency>
       <dependency>
         <groupId>commons-cli</groupId>
         <artifactId>commons-cli</artifactId>
-        <version>1.4</version>
+        <version>1.5.0</version>
       </dependency>
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.8.0</version>
+        <version>2.11.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
@@ -91,21 +91,21 @@
         <version>${ibm-fhir-server.version}</version>
       </dependency>
       <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>4.13.2</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>3.7.7</version>
+        <version>4.2.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-inline</artifactId>
-        <version>3.7.7</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.alvearie</groupId>
-        <artifactId>keycloak-config</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>4.2.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -117,13 +117,13 @@
       <dependency>
         <groupId>io.rest-assured</groupId>
         <artifactId>rest-assured</artifactId>
-        <version>4.1.2</version>
+        <version>4.4.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
-        <version>1.2.3</version>
+        <version>1.2.9</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -135,13 +135,13 @@
       <dependency>
         <groupId>io.github.bonigarcia</groupId>
         <artifactId>webdrivermanager</artifactId>
-        <version>4.4.3</version>
+        <version>5.0.3</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>com.squareup.okhttp3</groupId>
         <artifactId>mockwebserver</artifactId>
-        <version>3.11.0</version>
+        <version>4.9.3</version>
         <scope>test</scope>
       </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -27,12 +27,6 @@
     <dependencies>
       <dependency>
         <groupId>org.keycloak</groupId>
-        <artifactId>keycloak-core</artifactId>
-        <version>${keycloak.version}</version>
-        <scope>provided</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.keycloak</groupId>
         <artifactId>keycloak-server-spi</artifactId>
         <version>${keycloak.version}</version>
         <scope>provided</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,11 @@
   <build>
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>3.2.0</version>
+        </plugin>
         <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
         <plugin>
           <groupId>org.eclipse.m2e</groupId>


### PR DESCRIPTION
This change updates PropertyGroup to align with the version in ibm/fhir
(where it was forked from), reverts the previous quick-fix for handling
null values, and adds PropertyGroup tests.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>