### PR TITLE
bump dependency versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@
 *.iml
 .idea/
 
+# VS Code
+.vscode/
+
 # Mac OS X
 .DS_Store
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN mvn -B package -DskipTests
 
 
 # Package stage
-FROM quay.io/keycloak/keycloak:16.1.1
+FROM quay.io/keycloak/keycloak:17.0.1
 
 # This can be overridden, but without this I've found the db vendor-detection in Keycloak to be brittle
 ENV DB_VENDOR=H2

--- a/keycloak-extensions/src/main/java/org/alvearie/keycloak/PatientSelectionForm.java
+++ b/keycloak-extensions/src/main/java/org/alvearie/keycloak/PatientSelectionForm.java
@@ -313,6 +313,8 @@ public class PatientSelectionForm implements Authenticator {
 
     @Override
     public void close() {
-        // NOOP
+        if (fhirClient != null) {
+            fhirClient.close();
+        }
     }
 }

--- a/keycloak-extensions/src/test/java/org/alvearie/keycloak/KeycloakContainerTest.java
+++ b/keycloak-extensions/src/test/java/org/alvearie/keycloak/KeycloakContainerTest.java
@@ -63,8 +63,7 @@ public class KeycloakContainerTest {
         keycloak.addFileSystemBind("target/dependency", "/opt/jboss/keycloak/modules/system/layers/base/com/ibm/fhir/main", BindMode.READ_ONLY);
         // Shouldn't be needed, but sometimes is: https://github.com/dasniko/testcontainers-keycloak/issues/15
         keycloak.withEnv("DB_VENDOR", "H2");
-        // Temporarily uncomment to keep the container running after the tests complete
-        // or keep it uncommented for reduced cycle time after https://github.com/dasniko/testcontainers-keycloak/issues/33
+        // Uncomment this to keep the container running after the tests complete
 //        keycloak.withReuse(true);
         keycloak.start();
     }

--- a/keycloak-extensions/src/test/resources/jboss/module.xml
+++ b/keycloak-extensions/src/test/resources/jboss/module.xml
@@ -2,10 +2,10 @@
 <module xmlns="urn:jboss:module:1.5" name="com.ibm.fhir">
   <!-- This module file is only used for testing; the real com.ibm.fhir module will come from jboss-fhir-provider -->
   <resources>
-    <resource-root path="fhir-provider-4.10.2.jar"/>
-    <resource-root path="fhir-config-4.10.2.jar"/>
-    <resource-root path="fhir-model-4.10.2.jar"/>
-    <resource-root path="fhir-core-4.10.2.jar"/>
+    <resource-root path="fhir-provider-4.11.1.jar"/>
+    <resource-root path="fhir-config-4.11.1.jar"/>
+    <resource-root path="fhir-model-4.11.1.jar"/>
+    <resource-root path="fhir-core-4.11.1.jar"/>
     <resource-root path="antlr4-runtime-4.9.3.jar"/>
     <resource-root path="commons-io-2.11.0.jar"/>
     <resource-root path="commons-text-1.9.jar"/>

--- a/pom.xml
+++ b/pom.xml
@@ -10,9 +10,9 @@
   <packaging>pom</packaging>
 
   <properties>
-    <keycloak.version>16.1.1</keycloak.version>
-    <testcontainers-keycloak.version>1.9.0</testcontainers-keycloak.version>
-    <ibm-fhir-server.version>4.10.2</ibm-fhir-server.version>
+    <keycloak.version>17.0.1</keycloak.version>
+    <testcontainers-keycloak.version>1.10.0</testcontainers-keycloak.version>
+    <ibm-fhir-server.version>4.11.1</ibm-fhir-server.version>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
   </properties>


### PR DESCRIPTION
keycloak 16.1.1 -> 17.0.1
testcontainers-keycloak 1.9.0 -> 1.10.0
ibm-fhir-server 4.10.2 -> 4.11.1

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>