### PR TITLE
use exec from the run script

### DIFF
--- a/keycloak-config/run.sh
+++ b/keycloak-config/run.sh
@@ -6,4 +6,4 @@
 ###############################################################################
 
 # Execute the cli jar
-java -cp 'jars/*' org.alvearie.keycloak.config.Main $@
+exec java -cp 'jars/*' org.alvearie.keycloak.config.Main $@


### PR DESCRIPTION
this allows the run command to be cancelled from command-line via control+c

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>