### PR TITLE
Bump keycloak to version 18.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,11 @@ COPY keycloak-config ./keycloak-config
 COPY jboss-fhir-provider ./jboss-fhir-provider
 COPY keycloak-extensions ./keycloak-extensions
 
-RUN mvn -B package -DskipTests
+RUN mvn -B clean package -DskipTests
 
 
 # Package stage
-FROM quay.io/keycloak/keycloak:17.0.1
+FROM quay.io/keycloak/keycloak:18.0.0-legacy
 
 # This can be overridden, but without this I've found the db vendor-detection in Keycloak to be brittle
 ENV DB_VENDOR=H2

--- a/keycloak-config/Dockerfile
+++ b/keycloak-config/Dockerfile
@@ -13,7 +13,7 @@ FROM maven:3-jdk-11-slim AS build
 COPY pom.xml ./
 COPY keycloak-config ./keycloak-config
 
-RUN mvn -B package -f keycloak-config -DskipTests
+RUN mvn -B clean package -f keycloak-config -DskipTests
 
 
 # Package stage

--- a/keycloak-extensions/src/main/java/org/alvearie/keycloak/PatientSelectionForm.java
+++ b/keycloak-extensions/src/main/java/org/alvearie/keycloak/PatientSelectionForm.java
@@ -177,10 +177,9 @@ public class PatientSelectionForm implements Authenticator {
         authedClientSession.setNote(OIDCLoginProtocol.ISSUER,
                 Urls.realmIssuer(session.getContext().getUri().getBaseUri(), context.getRealm().getName()));
 
-        // Note: this depends on the corresponding string being registered as a valid scope for this client, otherwise it comes back empty
-        Stream<ClientScopeModel> readPatient = TokenManager.getRequestedClientScopes(SMART_SCOPE_PATIENT_READ, client);
-        ClientSessionContext clientSessionCtx = DefaultClientSessionContext.fromClientSessionAndClientScopes(authedClientSession,
-                readPatient, session);
+        // Note: this depends on the corresponding string being registered as a valid scope for this client
+        ClientSessionContext clientSessionCtx = DefaultClientSessionContext.fromClientSessionAndScopeParameter(authedClientSession,
+                SMART_SCOPE_PATIENT_READ, session);
 
         String requestedAudience = authSession.getClientNote(SMART_AUDIENCE_PARAM);
         if (requestedAudience == null) {

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <packaging>pom</packaging>
 
   <properties>
-    <keycloak.version>17.0.1</keycloak.version>
+    <keycloak.version>18.0.0</keycloak.version>
     <testcontainers-keycloak.version>1.10.0</testcontainers-keycloak.version>
     <ibm-fhir-server.version>4.11.1</ibm-fhir-server.version>
     <maven.compiler.target>11</maven.compiler.target>


### PR DESCRIPTION
We now specify '-legacy' for the docker image to get the
backwards-compatible wildfly-based distribution.

Moving forward, we'll need to look into the newer Quarkus-based
distribution.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>