### PR TITLE
issue #44 - remove all stale client scopes before adding new ones

### DIFF
--- a/keycloak-config/src/main/resources/config/keycloak-config.json
+++ b/keycloak-config/src/main/resources/config/keycloak-config.json
@@ -557,9 +557,10 @@
 						}
 					}
 				},
-				"defaultDefaultClientScopes": ["launch/patient"],
+				"defaultDefaultClientScopes": [],
 				"defaultOptionalClientScopes": [
 					"fhirUser",
+					"launch/patient",
 					"offline_access",
 					"online_access",
 					"profile",


### PR DESCRIPTION
Previously, we removed the stale defaultClientScopes, then added the new
ones.  However, since we weren't removing the stale optionalClientScopes
first, this could lead to unexpected behavior.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>